### PR TITLE
Aligning the indentation of the code blocks with their upstream list

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,33 +275,33 @@ The TOPSIS method, defined in [topsis.jl](https://github.com/jbytecode/JMcDM/blo
 ### The design pattern
 - ```topsis()``` takes the decision matrix, weights, and vector of directions of optimization as arguments. This function is defined in ```topsis.jl```.
 
-```julia
+   ```julia
    function topsis(decisionMat::Matrix, weights::Array{Float64,1}, fns::Array{Function,1})::TopsisResult
-```
+   ```
 
 - ```topsis()``` method has a return type of ```TopsisResult```. This ```struct``` is defined in ```types.jl```
 
-```julia
-  struct TopsisResult <: MCDMResult
-    decisionMatrix::Matrix
-    weights::Array{Float64,1}
-    normalizedDecisionMatrix::DataFrame
-    normalizedWeightedDecisionMatrix::DataFrame 
-    bestIndex::Int64 
-    scores::Array{Float64,1}
-end
-```
+   ```julia
+   struct TopsisResult <: MCDMResult
+      decisionMatrix::Matrix
+      weights::Array{Float64,1}
+      normalizedDecisionMatrix::DataFrame
+      normalizedWeightedDecisionMatrix::DataFrame 
+      bestIndex::Int64 
+      scores::Array{Float64,1}
+   end
+   ```
 
 - Optionally, a ```show``` function can be derived for pretty-printing the result. These functions are defined in ```print.jl```
 
-```julia
-function Base.show(io::IO, result::TopsisResult)
-    println(io, "Scores:")
-    println(io, result.scores)
-    println(io, "Best indices:")
-    println(io, result.bestIndex)
-end
-```
+   ```julia
+   function Base.show(io::IO, result::TopsisResult)
+      println(io, "Scores:")
+      println(io, result.scores)
+      println(io, "Best indices:")
+      println(io, result.bestIndex)
+   end
+   ```
 
 Please read the issue [Welcome to newcomers!](https://github.com/jbytecode/JMcDM/issues/3) for other implementation details.
 


### PR DESCRIPTION
In the design pattern section, the code blocks aren't correctly aligned with their upstream list. This PR aims to fix it. Here is the preview of the change:  
![image](https://github.com/jbytecode/JMcDM/assets/52105833/6ad72722-7a50-4794-bc9b-a8537555d610)
