### PR TITLE
(re-)export subtypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["Mehmet Hakan Satman (jbytecode) <mhsatman@gmail.com>", "Bahadir Fati
 version = "0.7.4"
 
 [deps]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]

--- a/src/JMcDM.jl
+++ b/src/JMcDM.jl
@@ -3,7 +3,8 @@ module JMcDM
 
 # Dependencies
 using Requires
-
+using Reexport
+@reexport using InteractiveUtils: subtypes
 
 # Modules Game, DataEnvelop, and SECA are activated 
 # whenever the JuMP and Ipopt packages are required


### PR DESCRIPTION
Hello, thanks for writing this package up.

In the examples for `mcdm`, the function `subtypes()` is used to obtain a list of available methods [see here](https://jbytecode.github.io/JMcDM/dev/utility/#mcdm).

```julia
julia> subtypes(MCDMMethod)
23-element Vector{Any}:
 ArasMethod
 CocosoMethod
 CodasMethod
 # ...
```

However, `subtypes()` is a part of the InteractiveUtils package and is not auto-included when using JMcDM programmatically.
To me, this breaks expectations given `subtypes()` is used to illustrate usage in the docs.

For example, given a script `example.jl`, with contents:

```julia
using JMcDM

@info subtypes(MCDMMethod)
```

Running the above results in an error:

```julia
julia --project=. example.jl
┌ Error: Exception while generating log record in module Main at C:\projects\JMcDM\example.jl:3
│   exception =
│    UndefVarError: `subtypes` not defined
│    Stacktrace:
│     [1] top-level scope
│       @ logging.jl:360
│     [2] include(mod::Module, _path::String)
│       @ Base .\Base.jl:457
│     [3] exec_options(opts::Base.JLOptions)
│       @ Base .\client.jl:307
│     [4] _start()
│       @ Base .\client.jl:522
└ @ Main C:\projects\JMcDM\example.jl:3
```

This PR re-exports `subtypes()` to avoid this.

I tried to think of a way to avoid having to depend on the entire `InteractiveUtils` package but it was the easiest approach.